### PR TITLE
Add mac, js, and jvm platforms for Multiplatform Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
 * [multiplatform-settings](https://github.com/russhwolf/multiplatform-settings) - For mobile apps to save settings as key-value pairs.  
 ![badge][badge-android]
 ![badge][badge-native]
+![badge][badge-mac]
+![badge][badge-js]
+![badge][badge-jvm]
 
 * [Kissme](https://github.com/netguru/Kissme) - This library provides encrypted key-value storage.  
 ![badge][badge-android]


### PR DESCRIPTION
Version 0.3+ now includes more platforms.

Tried to change [badge-native] to [badge-ios] but it doesn't appear to render, so I left that alone.