### PR TITLE
suparnatural-graphql: Strict Type Safe GraphQL client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
 
 * [kgql](https://github.com/yshrsmz/kgql) - GraphQL Document wrapper generator.
 
+* [suparnatural-graphql](https://github.com/suparngp/kotlin-multiplatform-projects/tree/master/graphql) - Strict type safe GraphQL client with support for composable links.
+![badge][badge-android]
+![badge][badge-native]
+![badge][badge-jvm]
+
 #### Stomp
 
 * [krossbow](https://github.com/joffrey-bion/krossbow) - A Kotlin multiplatform coroutine-based STOMP client over websockets  


### PR DESCRIPTION
- Generates strict types from GraphQL operations
- Isolate GraphQL from business logic by composable links

Link to docs
https://kmpdocs.suparnatural.com/graphql/
