### PR TITLE
Add ReKamp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,11 @@
 ![badge][badge-mac]
 ![badge][badge-wasm]
 
+* [ReKamp](https://github.com/xorum-io/ReKamp) - Port of [ReKotlin](https://github.com/ReKotlin/ReKotlin) to Kotlin Multiplatform, which corresponds to [ReKotlin/1.0.4](https://github.com/ReKotlin/ReKotlin/releases/tag/1.0.4).   
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+
 #### Project templates 
 
 * [moko-template](https://github.com/icerockdev/moko-template) - Template project of a Mobile (Android & iOS) Kotlin MultiPlatform project with the MOKO libraries and modularized architecture   


### PR DESCRIPTION
Port of [ReKotlin](https://github.com/ReKotlin/ReKotlin) to Kotlin Multiplatform, which corresponds to [ReKotlin/1.0.4](https://github.com/ReKotlin/ReKotlin/releases/tag/1.0.4). Supports **JVM**, **Android**, **iOS**.

Useful links:
- GitHub repo: https://github.com/xorum-io/ReKamp
- Bintray repo: https://bintray.com/beta/#/xorum-io/ReKamp/ReKamp
- Example of usage: https://github.com/xorum-io/codeforces_watcher/blob/dev/common/build.gradle