### PR TITLE
Add Kotlin utilities library

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,20 @@
 ![badge][badge-jvm]
 ![badge][badge-js]
 
+#### Monads
+
+* [Kotlin utilities](https://czerwinski.it/projects/kotlin-util/) - Scala utility types: `Option`, `Either`, `Try` for Kotlin Multiplatform.  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-wasm]
+
 ### Debug
 
 #### Logging


### PR DESCRIPTION
This library contains a few monads that I found very useful in Scala, and that I couldn't cope without in Kotlin: `Option`, `Try` and `Either`.
It's a port of Scala sources to Kotlin Multiplatform with Kotlin naming conventions and some additional extension functions.

Links:
* [Library page](https://czerwinski.it/projects/kotlin-util/)
* [Library sources](https://github.com/sczerwinski/kotlin-util)
