### PR TITLE
Add compose-macos-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,10 @@
 
 ### GUI
 
+* [compose-macos-theme](https://github.com/chozzle/compose-macos-theme) - Multiplatform MacOS theme written in Compose UI
+![badge][badge-android]
+![badge][badge-jvm]
+  
 * [moko-widgets](https://github.com/icerockdev/moko-widgets) - Declarative UI and screens management in common code for mobile (android & ios) Kotlin Multiplatform development  
 ![badge][badge-android]
 ![badge][badge-ios]

--- a/README.md
+++ b/README.md
@@ -516,10 +516,6 @@
 ![badge][badge-jvm]
 
 ### GUI
-
-* [compose-macos-theme](https://github.com/chozzle/compose-macos-theme) - Multiplatform MacOS theme written in Compose UI
-![badge][badge-android]
-![badge][badge-jvm]
   
 * [moko-widgets](https://github.com/icerockdev/moko-widgets) - Declarative UI and screens management in common code for mobile (android & ios) Kotlin Multiplatform development  
 ![badge][badge-android]
@@ -539,6 +535,11 @@
 
 * [kotlin-material-ui](https://github.com/subroh0508/kotlin-material-ui) - Kotlin Wrapper Library of Material-UI  
 ![badge][badge-js]
+
+
+* [compose-macos-theme](https://github.com/chozzle/compose-macos-theme) - Multiplatform MacOS theme written in Compose UI  
+![badge][badge-android]
+![badge][badge-jvm]
 
 ### Command Line Interface
 

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@
 ![badge][badge-jvm]
 
 ### GUI
-  
+
 * [moko-widgets](https://github.com/icerockdev/moko-widgets) - Declarative UI and screens management in common code for mobile (android & ios) Kotlin Multiplatform development  
 ![badge][badge-android]
 ![badge][badge-ios]
@@ -535,7 +535,6 @@
 
 * [kotlin-material-ui](https://github.com/subroh0508/kotlin-material-ui) - Kotlin Wrapper Library of Material-UI  
 ![badge][badge-js]
-
 
 * [compose-macos-theme](https://github.com/chozzle/compose-macos-theme) - Multiplatform MacOS theme written in Compose UI  
 ![badge][badge-android]


### PR DESCRIPTION
I've created this library https://github.com/Chozzle/compose-macos-theme
It could be very useful for anyone wanting to write a Multiplatform app UI, that appears native. 