### PR TITLE
Adding connectivity status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 
+#### Utility
+
+* [Connectivity status](https://github.com/ln-12/multiplatform-connectivity-status) - Monitor the internet connection status of your device on Android and iOS.  
+![badge][badge-android]
+![badge][badge-ios]
+
 ### Serializer
 
 * [kotlinx.serialization (official)](https://github.com/Kotlin/kotlinx.serialization) - Kotlin multiplatform / multi-format serialization  


### PR DESCRIPTION
Adds the [connectivity status](https://github.com/ln-12/multiplatform-connectivity-status) library. It is a helpful utility if you want to monitor the device connection state.