### PR TITLE
Add iOS badge to Kable

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@
 
 * [Kable](https://github.com/juullabs/kable) - Simple Coroutines-powered API for interacting with Bluetooth Low Energy devices.  
 ![badge][badge-android]
+![badge][badge-ios]
 ![badge][badge-js]
 ![badge][badge-mac]
 


### PR DESCRIPTION
https://github.com/JuulLabs/kable/pull/64 added support for iOS to the Kable library.

_Draft until release is published._