### PR TITLE
Add linux, windows and macOS badge to Ktor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 ![badge][badge-ios]
 ![badge][badge-js]
 ![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
 
 * [ktor-client-oauth-feature](https://github.com/kuuuurt/ktor-client-oauth-feature) - Ktor Client Feature for handling OAuth token refreshes  
 ![badge][badge-ios]


### PR DESCRIPTION
According to the docs Ktor does support the 3 desktop platform

https://ktor.io/docs/http-client-multiplatform.html#posix-compatible-desktops-macos-linux-windows