### PR TITLE
Add kotlin-multiplatform-diff - a library for calculating text differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@
 ![badge][badge-tvos]
 ![badge][badge-wasm]
 
-* [kotlin-multiplatform-diff](https://github.com/petertrr/kotlin-multiplatform-diff) - Multiplatform Kotlin library for calculating text differences.
+* [kotlin-multiplatform-diff](https://github.com/petertrr/kotlin-multiplatform-diff) - Multiplatform Kotlin library for calculating text differences.  
 ![badge][badge-js]
 ![badge][badge-jvm]
 ![badge][badge-linux]

--- a/README.md
+++ b/README.md
@@ -379,6 +379,13 @@
 ![badge][badge-tvos]
 ![badge][badge-wasm]
 
+* [kotlin-multiplatform-diff](https://github.com/petertrr/kotlin-multiplatform-diff) - Multiplatform Kotlin library for calculating text differences.
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+  
 #### Input/Output
 
 * [keyboard-mouse-kt](https://github.com/Animeshz/keyboard-mouse-kt) - Multiplatform Kotlin library for interacting with global keyboard and mouse events and states.  


### PR DESCRIPTION
kotlin-multiplatform-diff - https://github.com/petertrr/kotlin-multiplatform-diff - is based on [java-diff-utils](https://github.com/java-diff-utils/java-diff-utils), rewritten in Kotlin with multiplatform support.