### PR TITLE
add decompose to the architecture category and update MVIKotlin targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,15 @@
 
 * [kompass](https://github.com/sellmair/kompass) - Kotlin Multiplatform Router for Android and iOS  
 
+* [Decompose](https://github.com/arkivanov/Decompose) - Kotlin Multiplatform lifecycle-aware business logic components (aka BLoCs) with routing functionality and pluggable UI (Jetpack Compose, SwiftUI, JS React, etc.), inspired by Badoos RIBs fork of the Uber RIBs framework.
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-mac]
+![badge][badge-tvos]
+![badge][badge-watchos]
+
 * [oolong](https://github.com/oolong-kt/oolong) - MVU for Kotlin Multiplatform  
 
 * [moko-mvvm](https://github.com/icerockdev/moko-mvvm) - MVVM architecture components for mobile multiplatform with LiveData (iOS and Android)   
@@ -730,6 +739,7 @@
 ![badge][badge-jvm]
 ![badge][badge-linux]
 ![badge][badge-mac]
+![badge][badge-watchos]
 
 * [ReduxKotlin](https://github.com/reduxkotlin/redux-kotlin) - Redux implementation for Kotlin (supports multiplatform JVM, native, JS, WASM)   
 ![badge][badge-android]


### PR DESCRIPTION
[Decompose](https://github.com/arkivanov/Decompose) is a KMP version of the business logic component (BLOC) pattern with navigation functionality and is made from the same author of [MVIKotlin](https://github.com/arkivanov/MVIKotlin). There is a [sample](https://github.com/JetBrains/compose-jb/tree/master/examples/todoapp) in the Jetbrains compose repository that showcases its usage with testing. 

Also updated the targets for MVIKotlin since [watchOS support was added](https://github.com/arkivanov/MVIKotlin/issues/229). 