### PR TITLE
Add encoding library

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,19 @@
 ![badge][badge-mac]
 ![badge][badge-watchos]
 ![badge][badge-tvos]
-  
+
+* [encoding](https://github.com/05nelsonm/component-encoding) - Base 16/32/64 encoding.  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+
 #### Input/Output
 
 * [keyboard-mouse-kt](https://github.com/Animeshz/keyboard-mouse-kt) - Multiplatform Kotlin library for interacting with global keyboard and mouse events and states.  
@@ -600,17 +612,6 @@
 ![badge][badge-jvm]
 ![badge][badge-ios]
 ![badge][badge-js]
-
-* [encoding](https://github.com/05nelsonm/component-encoding) - Base 16/32/64 encoding.  
-![badge][badge-android]
-![badge][badge-ios]
-![badge][badge-js]
-![badge][badge-jvm]
-![badge][badge-linux]
-![badge][badge-windows]
-![badge][badge-mac]
-![badge][badge-watchos]
-![badge][badge-tvos]
 
 ### Debug
 

--- a/README.md
+++ b/README.md
@@ -601,6 +601,17 @@
 ![badge][badge-ios]
 ![badge][badge-js]
 
+* [encoding](https://github.com/05nelsonm/component-encoding) - Base 16/32/64 encoding.  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+
 ### Debug
 
 #### Logging


### PR DESCRIPTION
Adds `component-encoding` library to `Utilities` section.

[Library Link](https://github.com/05nelsonm/component-encoding)
Because encoding is a must have in most any project :smile: