### PR TITLE
Add `kmp-tor` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
 ![badge][badge-ios]
 ![badge][badge-jvm]
 
+* [kmp-tor](https://github.com/05nelsonm/kmp-tor) - Embed Tor into your application.  
+![badge][badge-android]
+![badge][badge-jvm]
+
 #### GraphQL
 
 * [apollo](https://www.apollographql.com/docs/android/essentials/get-started-multiplatform/) - Multiplatform official GraphQL client.  


### PR DESCRIPTION
Adds the `kmp-tor` library to the `Network.Http` section

[Library Link](https://github.com/05nelsonm/kmp-tor)

`kmp-tor` is a library for embedding Tor into an application for facilitating access to the Tor network.