### PR TITLE
Remove "platform" prefix on badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,16 +959,16 @@ fully covered API and a lot of additional DSLs on top of base API.
 Welcome contribute!
 Please read the [contribution guidelines](Contributing.md) first.
 
-[badge-android]: http://img.shields.io/badge/platform-android-6EDB8D.svg?style=flat
-[badge-jvm]: http://img.shields.io/badge/platform-jvm-DB413D.svg?style=flat
-[badge-js]: http://img.shields.io/badge/platform-js-F8DB5D.svg?style=flat
+[badge-android]: http://img.shields.io/badge/-android-6EDB8D.svg?style=flat
+[badge-jvm]: http://img.shields.io/badge/-jvm-DB413D.svg?style=flat
+[badge-js]: http://img.shields.io/badge/-js-F8DB5D.svg?style=flat
 [badge-js-ir]: https://img.shields.io/badge/support-[IR]-AAC4E0.svg?style=flat
-[badge-nodejs]: https://img.shields.io/badge/platform-nodejs-68a063.svg?style=flat
-[badge-linux]: http://img.shields.io/badge/platform-linux-2D3F6C.svg?style=flat 
-[badge-windows]: http://img.shields.io/badge/platform-windows-4D76CD.svg?style=flat
-[badge-wasm]: https://img.shields.io/badge/platform-wasm-624FE8.svg?style=flat
+[badge-nodejs]: https://img.shields.io/badge/-nodejs-68a063.svg?style=flat
+[badge-linux]: http://img.shields.io/badge/-linux-2D3F6C.svg?style=flat 
+[badge-windows]: http://img.shields.io/badge/-windows-4D76CD.svg?style=flat
+[badge-wasm]: https://img.shields.io/badge/-wasm-624FE8.svg?style=flat
 [badge-apple-silicon]: http://img.shields.io/badge/support-[AppleSilicon]-43BBFF.svg?style=flat
-[badge-ios]: http://img.shields.io/badge/platform-ios-CDCDCD.svg?style=flat
-[badge-mac]: http://img.shields.io/badge/platform-macos-111111.svg?style=flat
-[badge-watchos]: http://img.shields.io/badge/platform-watchos-C0C0C0.svg?style=flat
-[badge-tvos]: http://img.shields.io/badge/platform-tvos-808080.svg?style=flat
+[badge-ios]: http://img.shields.io/badge/-ios-CDCDCD.svg?style=flat
+[badge-mac]: http://img.shields.io/badge/-macos-111111.svg?style=flat
+[badge-watchos]: http://img.shields.io/badge/-watchos-C0C0C0.svg?style=flat
+[badge-tvos]: http://img.shields.io/badge/-tvos-808080.svg?style=flat


### PR DESCRIPTION
Most of the badges are platforms so this is an attempt to make the readme cleaner/more condensed

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/3859425/160603719-ec51fc1d-4bbf-4cca-8162-613bfc18692d.png) | ![image](https://user-images.githubusercontent.com/3859425/160603730-3d0e6408-1bda-4717-8084-4305b62dbc47.png) |