### PR TITLE
Add `multiplatform-viewmodel` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,13 @@
 ![badge][badge-jvm]
 ![badge][badge-js]
 
+* [Premo](https://github.com/doublesymmetry/multiplatform-viewmodel) — Shared ViewModel in Kotlin Multiplatform   
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+
 
 #### Project templates 
 


### PR DESCRIPTION
Adds the `multiplatform-viewmodel` library to the Architecture section

[Library Link](https://github.com/doublesymmetry/multiplatform-viewmodel)

`multiplatform-viewmodel` is a library providing a shared `ViewModel` to use in your presentation layer