### PR TITLE
Add sebj/time to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,15 @@
 ![badge][badge-mac]
 ![badge][badge-watchos]
 
+* [time](https://github.com/sebj/time) - Type-safe time periods for the Kotlinx-datetime multiplatform date/time library  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-mac]
+![badge][badge-tvos]
+![badge][badge-watchos]
+
 * [fluid-time](https://github.com/fluidsonic/fluid-time) - Kotlin multiplatform date & time library  
 ![badge][badge-ios]
 ![badge][badge-jvm]


### PR DESCRIPTION
# Time

* Type-safe time periods for the Kotlinx-datetime multiplatform date/time library

[Library Link](https://github.com/sebj/time)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

