### PR TITLE
Add Résultat library

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,16 @@
 ![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
+* [Résultat](https://github.com/nicolashaan/resultat) - A fork of Kotlin Result with a loading state.  
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-ios]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-apple-silicon]
+
 ### Debug
 
 #### Logging


### PR DESCRIPTION
# Résultat

* Résultat is a fork of Kotlin [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/) with a loading state.

* [Library Link](https://github.com/nicolashaan/resultat)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

