### PR TITLE
added link to compose_bloc:

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,6 +906,12 @@
 ![badge][badge-ios]
 ![badge][badge-js]
 
+* [compose_bloc](https://github.com/beyondeye/compose_bloc) - State Management and Navigation Library for Jetpack Compose and Compose Multiplatform.   
+![badge][badge-android]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
 
 #### Project templates 
 


### PR DESCRIPTION
# compose_bloc

* compose_bloc is a state management and navigation library for compose multiplatform

[compose_bloc](https://github.com/beyondeye/compose_bloc)

---

- [ x ] Confirmed that two spaces were added at the end of the description to break a new line.  

