### PR TITLE
Adding Ktoml library

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@
 ![badge][badge-watchos]
 ![badge][badge-windows]
 
+* [Ktoml](https://github.com/akuleshov7/ktoml) - MPP serialization library (decoder/encoder) for TOML format.
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-mac]
+![badge][badge-tvos]
+![badge][badge-watchos]
+![badge][badge-windows]
+
 ### Storage
 
 #### RDB

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@
 ![badge][badge-watchos]
 ![badge][badge-windows]
 
-* [Ktoml](https://github.com/akuleshov7/ktoml) - MPP serialization library (decoder/encoder) for TOML format.
+* [Ktoml](https://github.com/akuleshov7/ktoml) - MPP serialization library (decoder/encoder) for TOML format.  
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-js]


### PR DESCRIPTION
# Library Title

Ktoml - MPP serialization library (decoder/encoder) for TOML format.

[Ktoml](https://github.com/akuleshov7/ktoml)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

