### PR TITLE
New Network lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@
 ![badge][badge-windows]
 ![badge][badge-mac]
 
+* [fuel](https://github.com/kittinunf/fuel) - The easiest HTTP networking library for Kotlin backed by Kotlinx Coroutines.
+![badge][badge-android]
+![badge][badge-jvm]
+
 #### GraphQL
 
 * [apollo](https://www.apollographql.com/docs/android/essentials/get-started-multiplatform/) - Multiplatform official GraphQL client.  

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 ![badge][badge-windows]
 ![badge][badge-mac]
 
-* [fuel](https://github.com/kittinunf/fuel) - The easiest HTTP networking library for Kotlin backed by Kotlinx Coroutines.
+* [fuel](https://github.com/kittinunf/fuel) - The easiest HTTP networking library for Kotlin backed by Kotlinx Coroutines.  
 ![badge][badge-android]
 ![badge][badge-jvm]
 


### PR DESCRIPTION
# Library Title - fuel
* Library description (If you want to write)
The easiest HTTP networking library for Kotlin backed by Kotlinx Coroutines.
[Library Link](https://github.com/kittinunf/fuel)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

