### PR TITLE
Added expressions evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,7 @@ fully covered API and a lot of additional DSLs on top of base API.
 
 ### Math
 
-* [Multiplatform expressions evaluator](https://github.com/murzagalin/multiplatform-expressions-evaluator) - Runtime infix expressions evaluator.
+* [Multiplatform expressions evaluator](https://github.com/murzagalin/multiplatform-expressions-evaluator) - Runtime infix expressions evaluator.  
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-js]

--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,19 @@ fully covered API and a lot of additional DSLs on top of base API.
 ![badge][badge-jvm]
 ![badge][badge-js]![badge][badge-js-ir]
 
+### Math
+
+* [Multiplatform expressions evaluator](https://github.com/murzagalin/multiplatform-expressions-evaluator) - Runtime infix expressions evaluator.
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-mac]
+![badge][badge-tvos]
+![badge][badge-watchos]
+![badge][badge-windows]
+
 ## Contribute
 
 Welcome contribute!


### PR DESCRIPTION
# Multiplatform expressions evaluator

* This is a kotlin multiplatform runtime [infix](https://en.wikipedia.org/wiki/Infix_notation) expressions evaluator.

[Library Link](https://github.com/murzagalin/multiplatform-expressions-evaluator)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

