### PR TITLE
Add `arkivanov/parcelize-darwin` to Serializer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@
 ![badge][badge-watchos]
 ![badge][badge-windows]
 
+* [parcelize-darwin](https://github.com/arkivanov/parcelize-darwin) - Kotlin/Native compiler plugin that generates Parcelable implementations for Darwin (Apple) targets.
+* ![badge][badge-ios]
+
 ### Storage
 
 #### RDB


### PR DESCRIPTION
# Parcelize-Darwin

> Kotlin/Native compiler plugin that generates Parcelable implementations for Darwin (Apple) targets. Allows writing Parcelable classes for all Darwin targets, similary to the Android's kotlin-parcelize plugin. Can be also used together with the kotlin-parcelize plugin to write Parcelable classes in the commonMain source set.

[parcelize-darwin](https://github.com/arkivanov/parcelize-darwin)

---

- [ ] Confirmed that two spaces were added at the end of the description to break a new line.  
