### PR TITLE
Add entries `parcelize`, `value-clazz` and update `encoding`

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,22 @@
 ![badge][badge-mac]
 ![badge][badge-apple-silicon]
 
+* [value-clazz](https://github.com/05nelsonm/component-value-clazz) - Functionally equivalent to a Kotlin `value class` that implements an interface, but inheritance based and compiles to platform code.  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-wasm]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
 ### Debug
 
 #### Logging

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@
 ![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
+* [parcelize](https://github.com/05nelsonm/component-parcelize) - Implement Android `Parcelable` from common code.  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-wasm]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
 ### Storage
 
 #### RDB

--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ Welcome contribute!
 Please read the [contribution guidelines](Contributing.md) first.
 
 [badge-android]: http://img.shields.io/badge/-android-6EDB8D.svg?style=flat
+[badge-android-native]: http://img.shields.io/badge/support-[AndroidNative]-6EDB8D.svg?style=flat
 [badge-jvm]: http://img.shields.io/badge/-jvm-DB413D.svg?style=flat
 [badge-js]: http://img.shields.io/badge/-js-F8DB5D.svg?style=flat
 [badge-js-ir]: https://img.shields.io/badge/support-[IR]-AAC4E0.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@
 ![badge][badge-watchos]
 ![badge][badge-windows]
 
+* [encoding](https://github.com/05nelsonm/component-encoding) - Rfc 4648 Section 4-8 compliant encoding (Base 16, 32 Crockford, 32 Default, 32 Hex, 64 Default, 64 Url Safe).  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-wasm]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
 ### Storage
 
 #### RDB
@@ -574,18 +590,6 @@
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-js]
-![badge][badge-jvm]
-![badge][badge-linux]
-![badge][badge-windows]
-![badge][badge-mac]
-![badge][badge-watchos]
-![badge][badge-tvos]
-
-* [encoding](https://github.com/05nelsonm/component-encoding) - Base 16/32/64 encoding.  
-![badge][badge-android]
-![badge][badge-ios]
-![badge][badge-js]
-![badge][badge-nodejs]
 ![badge][badge-jvm]
 ![badge][badge-linux]
 ![badge][badge-windows]


### PR DESCRIPTION
# Library Title(s)
 - `parcelize`
     - [REPOSITORY](https://github.com/05nelsonm/component-parcelize)
     - Enables the implementing of `android.os.Parcelable` interface from `commonMain` source set
 - `encoding`
     - [REPOSITORY](https://github.com/05nelsonm/component-encoding)
     - Updated entry:
         - Description modification
         - Added support badges
         - Moved to section `Serialization`
 - `value-clazz`
     - [REPOSITORY](https://github.com/05nelsonm/component-value-clazz)
     - Abstraction that is functionally equivalent to a Kotlin `value class` that implements an `interface`, but will compile to platform code (unlike Kotlin `value class`es such as `kotlin.Result`)

I also added a badge in there for `android-native` that is similar to the `support [AppleSilicon]` and `support [IR]` badges. Can remove if you object, hopefully not :crossed_fingers: !

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  