### PR TITLE
add event4k library

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,21 @@
 ![badge][badge-android]
 ![badge][badge-ios]
 
+* [Event4k](https://github.com/nort3x/Event4k) - MultiPlatform Kotlin EventBus library - simple, bidirectional, concurrent.  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-js-ir]
+![badge][badge-nodejs]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-wasm]
+![badge][badge-apple-silicon]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+
 #### Number
 
 * [kotlin-multiplatform-bignum](https://github.com/ionspin/kotlin-multiplatform-bignum) - A Kotlin multiplatform library for arbitrary precision arithmetics  


### PR DESCRIPTION
# Event4k

* simple, bidirectional eventbus library written in common multiplatform kotlin,it has some extra features like inspection/removing hook, mutex-locking for concurrent publish/add from current eventbus library stated in the list

[Event4k](https://github.com/nort3x/event4k)

---

- [X] Confirmed that two spaces were added at the end of the description to break a new line.  

