### PR TITLE
Add Swift Klib gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,8 @@
 
 * [multiplatform-swiftpackage](https://github.com/ge-org/multiplatform-swiftpackage) - This is a Gradle plugin for Kotlin Multiplatform projects that generates an XCFramework for your native Apple targets and creates a matching Package.swift file to distribute it as a binary target.  
 
+* [Swift Klib](https://github.com/ttypic/swift-klib-plugin) - This is a Gradle Plugin to build Swift code as part of your Kotlin Multiplatform project. With this plugin, you can access Swift-only iOS libraries, such as CryptoKit and experiment with Swift to Kotlin interoperability.  
+
 ### Artificial Intelligence
 
 #### Symbolic AI


### PR DESCRIPTION
# Swift Klib gradle plugin

Swift Klib helps easily include your Swift source files in your KMM shared module and access them in Kotlin via cinterop for iOS targets. It is useful for:

* Accessing Swift-only libraries
* Creating a Kotlin-Friendly Swift API
* Learning how Swift <-> Kotlin interoperability works

[Library Link](https://github.com/ttypic/swift-klib-plugin)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

