### PR TITLE
Add `kmp-viewmodel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,15 @@
 ![badge][badge-ios]
 ![badge][badge-jvm]
 
+* [kmp-viewmodel](https://github.com/hoc081098/kmp-viewmodel) - Shared ViewModel in Kotlin Multiplatform - A Kotlin Multiplatform library that provides shared MVVM for UI applications. Components are lifecycle-aware on Android.
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-mac]
+![badge][badge-tvos]
+![badge][badge-watchos]
+
 #### Project templates 
 
 * [moko-template](https://github.com/icerockdev/moko-template) - Template project of a Mobile (Android & iOS) Kotlin MultiPlatform project with the MOKO libraries and modularized architecture   

--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,7 @@
 ![badge][badge-ios]
 ![badge][badge-jvm]
 
-* [kmp-viewmodel](https://github.com/hoc081098/kmp-viewmodel) - Shared ViewModel in Kotlin Multiplatform - A Kotlin Multiplatform library that provides shared MVVM for UI applications. Components are lifecycle-aware on Android.
+* [kmp-viewmodel](https://github.com/hoc081098/kmp-viewmodel) - Shared ViewModel in Kotlin Multiplatform - A Kotlin Multiplatform library that provides shared MVVM for UI applications. Components are lifecycle-aware on Android.  
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-jvm]


### PR DESCRIPTION
# kmp-viewmodel

* Shared ViewModel in Kotlin Multiplatform - A Kotlin Multiplatform library that provides shared MVVM for UI applications. Components are lifecycle-aware on Android.

* Supports Android Parcelable, Kotlin Parcelize, AndroidX SavedStateHandle for restoring state after process death.

* The ViewModel class is a business logic or screen level state holder. It exposes state to the UI and encapsulates related business logic. Its principal advantage is that it caches state and persists it through configuration changes (on Android).

[Library Link](https://github.com/hoc081098/kmp-viewmodel)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

