### PR TITLE
Add KStateMachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,6 +1073,11 @@
 ![badge][badge-js]
 ![badge][badge-windows]
 
+* [KStateMachine](https://github.com/nsk90/kstatemachine) - KStateMachine is a Kotlin DSL library for creating state machines and hierarchical state machines (statecharts).  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+
 * [Premo](https://github.com/dmdevgo/Premo) — Presentation Model (aka View Model) and Navigation. Focus on writing logic instead of solving common and boring UI related issues: lifecycle, persistence, navigation, etc.   
 ![badge][badge-android]
 ![badge][badge-ios]


### PR DESCRIPTION
# KStateMachine

* KStateMachine is a Kotlin DSL library for creating state machines and hierarchical state machines (statecharts).

[Library Link](https://github.com/nsk90/kstatemachine)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

