### PR TITLE
Add `KotlinCrypto` libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@
 * [secure-random](https://github.com/05nelsonm/secure-random) - Cryptographically secure random number generator, `SecureRandom`.   
 ![badge][badge-android]
 ![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
 ![badge][badge-linux]
 ![badge][badge-windows]
 ![badge][badge-ios]
@@ -595,6 +597,7 @@
 ![badge][badge-watchos]
 ![badge][badge-tvos]
 ![badge][badge-android-native]
+![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
 #### String Utils

--- a/README.md
+++ b/README.md
@@ -631,6 +631,54 @@
 ![badge][badge-windows]
 ![badge][badge-linux]
 
+* [KotlinCrypto/hash](https://github.com/KotlinCrypto/hash) - Hash functions (MD5/SHA1/SHA2/SHA3).   
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-wasm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
+* [KotlinCrypto/MACs](https://github.com/KotlinCrypto/MACs) - Message Authentication Code functions (Hmac MD5/SHA1/SHA2/SHA3, KMAC).   
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-wasm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
+* [KotlinCrypto/sponges](https://github.com/KotlinCrypto/sponges) - Sponge functions & state (Keccak-p).   
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-wasm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
 #### Cipher
 
 * [krypt](https://github.com/korlibs/krypto) - Cryptography library. Support for SecureRandom, Hash(MD5/SHA1/SHA256), AES.  
@@ -653,7 +701,7 @@
 ![badge][badge-watchos]
 ![badge][badge-tvos]
 
-* [secure-random](https://github.com/05nelsonm/secure-random) - Cryptographically secure random number generator, `SecureRandom`.   
+* [KotlinCrypto/secure-random](https://github.com/KotlinCrypto/secure-random) - Cryptographically secure random number generator, `SecureRandom`.   
 ![badge][badge-android]
 ![badge][badge-jvm]
 ![badge][badge-js]
@@ -792,6 +840,22 @@
 * [Measured](https://github.com/nacular/measured) - Intuitive, type-safe units of measure.  
 ![badge][badge-jvm]
 ![badge][badge-js]
+
+* [KotlinCrypto/endians](https://github.com/KotlinCrypto/endians) - Utils for converting `Short`, `Int`, `Long` to/from `BigEndian` and `LittleEndian` bytes.   
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-wasm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-android-native]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
 
 #### Monads
 

--- a/README.md
+++ b/README.md
@@ -585,6 +585,18 @@
 ![badge][badge-watchos]
 ![badge][badge-tvos]
 
+* [secure-random](https://github.com/05nelsonm/secure-random) - Cryptographically secure random number generator, `SecureRandom`.   
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-android-native]
+![badge][badge-apple-silicon]
+
 #### String Utils
 
 * [FuzzyWuzzy-Kotlin](https://github.com/willowtreeapps/fuzzywuzzy-kotlin) - Fuzzy string matching on collections.  Port of python & java library.


### PR DESCRIPTION
# KotlinCrypto
 - `KotlinCrypto/hash`
 - `KotlinCrypto/MACs`
 - `KotlinCrypto/sponges`
 - `KotlinCrypto/secure-random`
 - `KotlinCrypto/endians`

All libs can be found under the [KotlinCrypto](https://github.com/KotlinCrypto) organization

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

