### PR TITLE
Add Kotter CLI multiplatform library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,6 +1022,12 @@
 ![badge][badge-linux]
 ![badge][badge-windows]
 
+* [Kotter](https://github.com/varabyte/kotter) - Multiplatform library for Kotlin command-line applications with support for text styling, animations, timers, and input.  
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+
 * [Mordant](https://github.com/ajalt/mordant) - Multiplatform text styling for Kotlin command-line applications  
 ![badge][badge-js]
 ![badge][badge-jvm]


### PR DESCRIPTION
# Kotter

* A declarative, Kotlin-idiomatic API for writing dynamic console applications.

[Kotter](https://github.com/varabyte/kotter)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

