### PR TITLE
Add Truthish multiplatform testing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,15 @@
 ![badge][badge-windows]
 ![badge][badge-linux]
 
+* [Truthish](https://github.com/varabyte/truthish) - Multiplatform library with a testing API inspired by Google Truth.  
+![badge][badge-jvm]
+![badge][badge-js]
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-windows]
+![badge][badge-linux]
+
 ### Annotation Processor
 
 * [MpApt](https://github.com/Foso/MpApt) - Kotlin Native/JS/JVM Annotation Processor library  


### PR DESCRIPTION
# Truthish

* A Kotlin multiplatform unit testing library inspired by / similar to Google Truth.

[Truthish](https://github.com/varabyte/truthish)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

