### PR TITLE
Update link to Korim

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@
 
 ### Image
 
-* [korim](https://github.com/korlibs/korim) - Kotlin cORoutines IMaging, Bitmap and Vector graphics for Multiplatform Kotlin   
+* [korim](https://github.com/korlibs/korge/tree/main/korim) - Kotlin cORoutines IMaging, Bitmap and Vector graphics for Multiplatform Kotlin   
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-js]


### PR DESCRIPTION
The old link went to an archived repository, which contained this link. I figured this would make it simpler if the link went straight to the target

