### PR TITLE
Add XMP Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,7 +985,7 @@
 
 #### Metadata
 
-* [XMP Core for Kotlin Multiplatform](https://github.com/Ashampoo/xmpcore) - Kotlin Multiplatform port of Adobe's XMP SDK  
+* [XMP Core for Kotlin Multiplatform](https://github.com/Ashampoo/xmpcore) - Kotlin Multiplatform port of Adobe's XMP SDK.  
 ![badge][badge-android]
 ![badge][badge-jvm]
 ![badge][badge-ios]

--- a/README.md
+++ b/README.md
@@ -985,7 +985,7 @@
 
 #### Metadata
 
-* [XMP Core for Kotlin Metadata](https://github.com/Ashampoo/xmpcore) - Kotlin Multiplatform port of Adobe's XMP SDK  
+* [XMP Core for Kotlin Multiplatform](https://github.com/Ashampoo/xmpcore) - Kotlin Multiplatform port of Adobe's XMP SDK  
 ![badge][badge-android]
 ![badge][badge-jvm]
 ![badge][badge-ios]

--- a/README.md
+++ b/README.md
@@ -983,6 +983,14 @@
 ![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
+#### Metadata
+
+* [XMP Core for Kotlin Metadata](https://github.com/Ashampoo/xmpcore) - Kotlin Multiplatform port of Adobe's XMP SDK  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-ios]
+![badge][badge-mac]
+
 ### Debug
 
 #### Logging


### PR DESCRIPTION
# XMP Core for Kotlin Multiplatform

This library is a port of Adobe's XMP SDK to Kotlin Multiplatform.

https://github.com/Ashampoo/xmpcore

---

- [X] Confirmed that two spaces were added at the end of the description to break a new line.  

