### PR TITLE
Added Couchbase lite to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@
 ![badge][badge-tvos]
 ![badge][badge-watchos]
 
-* [Couchbaselite](https://github.com/MyUNiDAYS/couchbaselite-kotlin-sdk) - Kotlin Multiplatform wrapper for the Couchbase Lite Mobile Database. 
+* [Couchbaselite](https://github.com/MyUNiDAYS/couchbaselite-kotlin-sdk) - Kotlin Multiplatform wrapper for the Couchbase Lite Mobile Database.  
 ![badge][badge-android]
 ![badge][badge-ios]
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@
 ![badge][badge-tvos]
 ![badge][badge-watchos]
 
+* [Couchbaselite](https://github.com/MyUNiDAYS/couchbaselite-kotlin-sdk) - Kotlin Multiplatform wrapper for the Couchbase Lite Mobile Database. 
+![badge][badge-android]
+![badge][badge-ios]
+
 #### KVS
 
 * [multiplatform-settings](https://github.com/russhwolf/multiplatform-settings) - A Kotlin Multiplatform library for saving simple key-value data.  


### PR DESCRIPTION

# Couchbase lite

* A KMP wrapper for couchbase lite

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

