### PR TITLE
Add DrawBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,12 @@
 ![badge][badge-jvm]
 ![badge][badge-js]
 
+* [DrawBox](https://github.com/MarkYav/DrawBox) - The first multiplatform library to draw anything on canvas.  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+
 ### Command Line Interface
 
 * [Clikt](https://github.com/ajalt/clikt) - Multiplatform command line interface parsing for Kotlin  


### PR DESCRIPTION
# DrawBox

* DrawBox is a multipurpose tool to draw anything on canvas, written completely on Compose Multiplatform. This is the first multiplatform drawing library!

[Library Link](https://github.com/MarkYav/DrawBox)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

