### PR TITLE
Added Typist-CMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,9 +1197,7 @@
 ![badge][badge-js]
 
 
-* [typist-cmp](https://github.com/zeeshanali-k/typist-cmp) - A Highly Customisable Typing Animation Library for Compose Multiplatform (Android & iOS)
-
-
+* [typist-cmp](https://github.com/zeeshanali-k/typist-cmp) - A Highly Customisable Typing Animation Library for Compose Multiplatform (Android & iOS)  
 ![badge][badge-android]
 ![badge][badge-ios]
 

--- a/README.md
+++ b/README.md
@@ -1197,7 +1197,9 @@
 ![badge][badge-js]
 
 
-* [typist-cmp]([https://github.com/icerockdev/moko-widgets](https://github.com/zeeshanali-k/typist-cmp)) - A Highly Customisable Typing Animation Library for Compose Multiplatform (Android & iOS)
+* [typist-cmp](https://github.com/zeeshanali-k/typist-cmp) - A Highly Customisable Typing Animation Library for Compose Multiplatform (Android & iOS)
+
+
 ![badge][badge-android]
 ![badge][badge-ios]
 

--- a/README.md
+++ b/README.md
@@ -1196,6 +1196,11 @@
 ![badge][badge-jvm]
 ![badge][badge-js]
 
+
+* [typist-cmp]([https://github.com/icerockdev/moko-widgets](https://github.com/zeeshanali-k/typist-cmp)) - A Highly Customisable Typing Animation Library for Compose Multiplatform (Android & iOS)
+![badge][badge-android]
+![badge][badge-ios]
+
 ### Command Line Interface
 
 * [Clikt](https://github.com/ajalt/clikt) - Multiplatform command line interface parsing for Kotlin  


### PR DESCRIPTION
# Typist-CMP

*   A Typing Animation Library for Compose Multiplatform

https://github.com/zeeshanali-k/typist-cmp

---

- [ Yes] Confirmed that two spaces were added at the end of the description to break a new line. 

