### PR TITLE
Add RssParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,13 @@
 ![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
+#### Parsing
+
+* [RSS-Parser](https://github.com/prof18/RSS-Parser) - A Kotlin Multiplatform library to parse a RSS Feed  
+![badge][badge-android]
+![badge][badge-jvm]
+![badge][badge-ios]
+
 ### Debug
 
 #### Logging


### PR DESCRIPTION
# RssParser

* RSS Parser is a Kotlin Multiplatform library for parsing RSS and Atom feeds. It supports Android, iOS, and the JVM.
* 
[Library Link](https://github.com/prof18/RSS-Parser)

--- 

I was not sure if it was fitting under the existing categories. So I created a "Parsing" subsection under "Utility". Let me know if it works for you or feel free to move it under a more appropriate section! 🙏 

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

