### PR TITLE
add jsmints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,9 @@
 ![badge][badge-windows]
 ![badge][badge-linux]
 
+* [jsmints](https://github.com/robertfmurdock/jsmints) - A suite of libraries and gradle plugins for working with Kotlin JS, with a focus on testing and version updating.  
+  ![badge][badge-js]
+
 ### Annotation Processor
 
 * [MpApt](https://github.com/Foso/MpApt) - Kotlin Native/JS/JVM Annotation Processor library  


### PR DESCRIPTION
# jsmints

* *jsmints* is a suite of libraries and gradle plugins for working with Kotlin JS, with a focus on testing and version updating.

[Library Link](https://github.com/robertfmurdock/jsmints)

---

- [✅] Confirmed that two spaces were added at the end of the description to break a new line.  

