### PR TITLE
Fix project name for jsonrpc-kotlin-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 
 #### JSON-RPC
 
-* [apollo](https://github.com/Reedyuk/jsonrpc-kotlin-client) -JSON-RPC Kotlin Multiplatform client.  
+* [jsonrpc-kotlin-client](https://github.com/Reedyuk/jsonrpc-kotlin-client) -JSON-RPC Kotlin Multiplatform client.  
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-jvm]


### PR DESCRIPTION


- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

