### PR TITLE
add AWS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,6 @@
 ![badge][badge-ios]
 ![badge][badge-jvm]
 
-
 #### NoSQL
 
 * [Realm](https://github.com/realm/realm-kotlin) - Kotlin Multiplatform and Android SDK for the Realm Mobile Database: Build Better Apps Faster.  

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 
+* [AWS - S3](https://github.com/estivensh4/aws-kmp) - AWSS3 is an AWS extension for KMP.
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+
+
 #### NoSQL
 
 * [Realm](https://github.com/realm/realm-kotlin) - Kotlin Multiplatform and Android SDK for the Realm Mobile Database: Build Better Apps Faster.  

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 
-* [AWS - S3](https://github.com/estivensh4/aws-kmp) - AWSS3 is an AWS extension for KMP.
+* [AWS - S3](https://github.com/estivensh4/aws-kmp) - AWS KMP is an extension to AWS Kotlin Multiplatform for JVM, Android and iOS.
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-jvm]
@@ -501,7 +501,7 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 ![badge][badge-linux]
-![badge][badge-mac]
+![badge][badge-mac]xx
 ![badge][badge-tvos]
 ![badge][badge-watchos]
 ![badge][badge-windows]

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 ![badge][badge-linux]
-![badge][badge-mac]xx
+![badge][badge-mac]
 ![badge][badge-tvos]
 ![badge][badge-watchos]
 ![badge][badge-windows]

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 
-* [AWS - S3](https://github.com/estivensh4/aws-kmp) - AWS KMP is an extension to AWS Kotlin Multiplatform for JVM, Android and iOS.
+* [AWS - S3](https://github.com/estivensh4/aws-kmp) - AWS KMP is an extension to AWS Kotlin Multiplatform for JVM, Android and iOS.  
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-jvm]


### PR DESCRIPTION
# AWS KMP

* AWSS3 is an AWS extension for kmp as there is currently no library that does it.

[AWS KMP](https://github.com/estivensh4/aws-kmp)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

