### PR TITLE
Add peekaboo

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,10 @@
 ![badge][badge-ios]
 ![badge][badge-mac]
 
+* [peekaboo](https://github.com/TEAM-PREAT/peekaboo) - Single & Multiple Image Selection and Maximum Image Count Setting Library for Compose Multiplatform (Android & iOS)
+![badge][badge-android]
+![badge][badge-ios]
+
 ### Audio
 
 * [korau](https://github.com/korlibs/korau) - Pure Kotlin WAV, MP3 and OGG vorbis decoders  
@@ -1358,10 +1362,6 @@
  ![badge][badge-windows]
  ![badge][badge-mac]
  ![badge][badge-js-ir]
-
-* [peekaboo](https://github.com/TEAM-PREAT/peekaboo) - Single & Multiple Image Selection and Maximum Image Count Setting Library for Compose Multiplatform (Android & iOS)
-![badge][badge-android]
-![badge][badge-ios]
 
 ### Command Line Interface
 

--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,10 @@
  ![badge][badge-mac]
  ![badge][badge-js-ir]
 
+* [peekaboo](https://github.com/TEAM-PREAT/peekaboo) - Single & Multiple Image Selection and Maximum Image Count Setting Library for Compose Multiplatform (Android & iOS)
+![badge][badge-android]
+![badge][badge-ios]
+
 ### Command Line Interface
 
 * [Clikt](https://github.com/ajalt/clikt) - Multiplatform command line interface parsing for Kotlin  


### PR DESCRIPTION
# peekaboo

* Kotlin Multiplatform library for Compose Multiplatform, designed for seamless integration of an image picker feature in iOS and Android applications.
* It has a multiple image picker feature + ability to select the maximum number of images for iOS and Android target.

[peekaboo](https://github.com/TEAM-PREAT/peekaboo)

![image](https://github.com/AAkira/Kotlin-Multiplatform-Libraries/assets/76798309/31b3bf54-fb01-4bfb-b62c-e7a23a4f1315)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

