### PR TITLE
ksoup library badges updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,12 +1082,19 @@
 * [Ksoup](https://github.com/fleeksoft/ksoup) - HTML & XML Parser (Jsoup Alternative)  
 ![badge][badge-android]
 ![badge][badge-jvm]
+![badge][badge-nodejs]
+![badge][badge-linux]
+![badge][badge-windows]
 ![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
 
 * [RSS-Parser](https://github.com/prof18/RSS-Parser) - A Kotlin Multiplatform library to parse a RSS Feed  
 ![badge][badge-android]
 ![badge][badge-jvm]
 ![badge][badge-ios]
+![badge][badge-mac]
 
 ### Debug
 


### PR DESCRIPTION
ksoup library badges updated

# Ksoup

* HTML & XML Parser

[Library Link](https://github.com/fleeksoft/ksoup)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

