### PR TITLE
Add Wavy slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,16 @@
  ![badge][badge-mac]
  ![badge][badge-js-ir]
 
+* [Wavy slider](https://github.com/mahozad/wavy-slider) - Animated squiggly slider (aka sperm) similar to the one in Android 13   
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-js-ir]
+
 ### Command Line Interface
 
 * [Clikt](https://github.com/ajalt/clikt) - Multiplatform command line interface parsing for Kotlin  


### PR DESCRIPTION
![Library demo](https://github.com/mahozad/wavy-slider/raw/main/assets/demo-movie.gif)
# Wavy slider

Multiplatform Material 2 and Material 3 animated slider similar to the one introduced in Android 13 media player.

See the live, interactive Web version in [its website](https://mahozad.ir/wavy-slider).



[Library Link](https://github.com/mahozad/wavy-slider)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

