### PR TITLE
Add kedis

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@
 ![badge][badge-android]
 ![badge][badge-ios]
 
+* [Kedis](https://github.com/domgew/kedis) - Redis client library for Kotlin Multiplatform (JVM + Native).  
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-mac]
+
 #### FILE
 
 * [okio](https://github.com/square/okio) - A modern I/O library for Android, Java, and Kotlin Multiplatform.  


### PR DESCRIPTION
# Kedis

* Redis client library for Kotlin Multiplatform (JVM + Native).

[Library Link](https://github.com/domgew/kedis)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

