### PR TITLE
Replace archived paging lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,11 @@
 
 #### Paging
 
-* [Multiplatform Paging](https://github.com/kuuuurt/multiplatform-paging) - Kotlin Multiplatform library for Pagination on Android and iOS  
+* ~~[Multiplatform Paging (Archived)](https://github.com/kuuuurt/multiplatform-paging) - Kotlin Multiplatform library for Pagination on Android and iOS~~ 
+![badge][badge-android]
+![badge][badge-ios]* 
+
+* [Multiplatform Paging](https://github.com/cashapp/multiplatform-paging) - A library that adds additional Kotlin/Multiplatform targets to AndroidX Paging, and provides UI components to use Paging on iOS. 
 ![badge][badge-android]
 ![badge][badge-ios]
 

--- a/README.md
+++ b/README.md
@@ -963,11 +963,11 @@
 
 #### Paging
 
-* ~~[Multiplatform Paging (Archived)](https://github.com/kuuuurt/multiplatform-paging) - Kotlin Multiplatform library for Pagination on Android and iOS~~ 
+* ~~[Multiplatform Paging (Archived)](https://github.com/kuuuurt/multiplatform-paging) - Kotlin Multiplatform library for Pagination on Android and iOS~~  
 ![badge][badge-android]
-![badge][badge-ios]* 
+![badge][badge-ios] 
 
-* [Multiplatform Paging](https://github.com/cashapp/multiplatform-paging) - A library that adds additional Kotlin/Multiplatform targets to AndroidX Paging, and provides UI components to use Paging on iOS. 
+* [Multiplatform Paging](https://github.com/cashapp/multiplatform-paging) - A library that adds additional Kotlin/Multiplatform targets to AndroidX Paging, and provides UI components to use Paging on iOS.  
 ![badge][badge-android]
 ![badge][badge-ios]
 


### PR DESCRIPTION
# multiplatform-paging

* A library that adds additional Kotlin/Multiplatform targets to AndroidX Paging, and provides UI components to use Paging on iOS. 

[Multiplatform Paging](https://github.com/cashapp/multiplatform-paging)

The old one is archived and I replaced it with another library which is recommended in the archived library.
---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

