### PR TITLE
Update `kmp-viewmodel`: add `wasm`, `nodejs` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1552,6 +1552,8 @@
 ![badge][badge-ios]
 ![badge][badge-jvm]
 ![badge][badge-js]
+![badge][badge-wasm]
+![badge][badge-nodejs]
 ![badge][badge-mac]
 ![badge][badge-tvos]
 ![badge][badge-watchos]


### PR DESCRIPTION
# kmp-viewmodel

[Library Link](https://github.com/hoc081098/kmp-viewmodel)

Since https://github.com/hoc081098/kmp-viewmodel/releases/tag/0.7.0, `wasm` target and `nodejs` target have been supported

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

