### PR TITLE
Add JsonPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,11 @@
 ![badge][badge-ios]
 ![badge][badge-mac]
 
+* [JsonPath](https://github.com/a-sit-plus/jsonpath) - Kotlin Multiplatform Library for using Json Paths as defined in [RFC9535](https://datatracker.ietf.org/doc/rfc9535).  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+
 ### Debug
 
 #### Logging


### PR DESCRIPTION
# JsonPath

* This is a Kotlin Multiplatform Library for using JSON Paths as defined in RFC9535.

[Library Link](https://github.com/a-sit-plus/jsonpath)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

