### PR TITLE
Add KMP-Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,11 @@
 ![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
+* [KMP-Crypto](https://github.com/a-sit-plus/kmp-crypto) - KMP Crypto Datatypes & ASN.1 Parser+Encoder.  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+
 #### String Utils
 
 * [FuzzyWuzzy-Kotlin](https://github.com/willowtreeapps/fuzzywuzzy-kotlin) - Fuzzy string matching on collections.  Port of python & java library.


### PR DESCRIPTION
# KMP-Crypto

* KMP Crypto Datatypes & ASN.1 Parser+Encoder

[Library Link](https://github.com/a-sit-plus/kmp-crypto)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

