### PR TITLE
Add KmmResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,17 @@
 ![badge][badge-js-ir]
 ![badge][badge-apple-silicon]
 
+* [KmmResult](https://github.com/a-sit-plus/KmmResult) - Wrapper of `kotlin.Result` with KMM goodness.  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+
 #### WebAssembly
 
 * [ktmpwasm](https://github.com/Yeicor/ktmpwasm) - A WebAssembly interpreter for Kotlin Multiplatform.  


### PR DESCRIPTION
# KmmResult

* Wrapper of `kotlin.Result` with KMM goodness to make it usable as part of XCFrameworks.

[Library Link](https://github.com/a-sit-plus/KmmResult)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

