### PR TITLE
Add VC Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@
 ![badge][badge-js]
 ![badge][badge-jvm]
 
+### Identity Wallet
+
+* [KMM VC Library](https://github.com/a-sit-plus/kmm-vc-library) - Kotlin Multiplatform library implementing W3C VC Data Model and ISO 18013-5 mDL.  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-jvm]
+
 ### Repository
 
 * [Store](https://github.com/MobileNativeFoundation/Store) - A Kotlin Multiplatform library for building network-resilient applications.  


### PR DESCRIPTION
# KMM VC Library

* This library implements verifiable credentials to support several use cases, i.e. issuing of credentials, presentation of credentials and validation thereof. This library may be shared between backend services issuing credentials, wallet apps holding credentials, and verifier apps validating them.  
Credentials may be represented in the [W3C VC Data Model](https://w3c.github.io/vc-data-model/) or as mobile driving licences from [ISO/IEC 18013-5:2021](https://www.iso.org/standard/69084.html). Issuing may happen according to [ARIES RFC 0453 Issue Credential V2](https://github.com/hyperledger/aries-rfcs/tree/main/features/0453-issue-credential-v2) or with [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html). Presentation of credentials may happen according to [ARIES RFC 0454 Present Proof V2](https://github.com/hyperledger/aries-rfcs/tree/main/features/0454-present-proof-v2) or with [Self-Issued OpenID Provider v2](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html).

[Library Link](https://github.com/a-sit-plus/kmm-vc-library)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

