### PR TITLE
add KaptureX

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,10 @@
 ![badge][badge-android]
 ![badge][badge-ios]
 
+* [KaptureX](https://github.com/estivensh4/kaptureX) - Camera and Video Library for Kotlin Multiplatform. 📸
+![badge][badge-android]
+![badge][badge-ios]
+
 ### Audio
 
 * [korau](https://github.com/korlibs/korau) - Pure Kotlin WAV, MP3 and OGG vorbis decoders  

--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@
 ![badge][badge-android]
 ![badge][badge-ios]
 
+
 ### Audio
 
 * [korau](https://github.com/korlibs/korau) - Pure Kotlin WAV, MP3 and OGG vorbis decoders  


### PR DESCRIPTION
# KaptureX

* Camera and Video Library for Kotlin Multiplatform. 📸

[KaptureX](https://github.com/estivensh4/kaptureX)

---

- [ ] Confirmed that two spaces were added at the end of the description to break a new line.  

