### PR TITLE
docs: Remove Klock from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,17 +591,6 @@
 ![badge][badge-windows]
 ![badge][badge-watchos]
 
-* [klock](https://github.com/korlibs/klock) - Multiplatform Date and time library for Kotlin  
-![badge][badge-android]
-![badge][badge-ios]
-![badge][badge-js]
-![badge][badge-jvm]
-![badge][badge-linux]
-![badge][badge-mac]
-![badge][badge-tvos]
-![badge][badge-windows]
-![badge][badge-watchos]
-
 * [island-time](https://github.com/erikc5000/island-time) - A Kotlin Multiplatform library for working with dates and times  
 ![badge][badge-android]
 ![badge][badge-ios]


### PR DESCRIPTION
# Klock

* The repository has been archived by the owner on Jul 8, 2022  and now it is now read-only. It is no longer recommended to use in new projects.

[Library Link](https://github.com/korlibs-archive/klock)

---

- [X] Confirmed that two spaces were added at the end of the description to break a new line.  

