### PR TITLE
add target badges for ksoup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,6 +1127,15 @@
 ![badge][badge-android]
 ![badge][badge-jvm]
 ![badge][badge-ios]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-apple-silicon]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-wasm]
+![badge][badge-linux]
+![badge][badge-windows]
 
 * [KtXml](https://github.com/kobjects/ktxml) - XML Parser (Basically a KXml2 port to Kotlin)  
 ![badge][badge-android]


### PR DESCRIPTION
# Ksoup

* Ksoup is a Kotlin Multiplatform library for working with HTML and XML.

[Library Link](https://github.com/fleeksoft/ksoup)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

