### PR TITLE
Add ItsOk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,6 +1023,21 @@
 
 #### Monads
 
+* [ItsOk](https://github.com/PaoloConte/kotlin-itsok) - A new take on the `Result` monad for clean error handling.   
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-nodejs]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-watchos]
+![badge][badge-tvos]
+![badge][badge-wasm]
+![badge][badge-js-ir]
+![badge][badge-apple-silicon]
+
 * [Kotlin utilities](https://czerwinski.it/projects/kotlin-util/) - Scala utility types: `Option`, `Either`, `Try` for Kotlin Multiplatform.  
 ![badge][badge-android]
 ![badge][badge-ios]


### PR DESCRIPTION
# ItsOk

* This is a little library that provides an improved way to use Result in Kotlin, with custom error types and also a way to avoid wrapping result objects into Ok and Error wrapper objects.

[Library Link](https://github.com/PaoloConte/kotlin-itsok)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

