### PR TITLE
feat: Add KMP-Places-Autocomplete lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,6 +1813,10 @@ fully covered API and a lot of additional DSLs on top of base API.
 ![badge][badge-watchos]
 ![badge][badge-windows]
 
+* [KMP-Places-Autocomplete](https://github.com/ngallazzi/KMP-Places-Autocomplete) - A lightweight and ready to use API to search places for Compose Multiplatform  
+![badge][badge-android]
+![badge][badge-ios]
+
 ## Contribute
 
 Welcome contribute!


### PR DESCRIPTION
# KMP-Places-Autocomplete

* A simple Compose Multiplatform library to fill addresses, cities and countries in a form, based on Google Places API by Google 

[Library Link](https://github.com/ngallazzi/KMP-Places-Autocomplete)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

