### PR TITLE
Add Lets-Plot Skia Frontend (Official)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1480,6 +1480,17 @@
 ![badge][badge-linux]
 ![badge][badge-windows]
 
+* [Lets-Plot Skia Frontend (official)](https://github.com/JetBrains/lets-plot) - a Kotlin Multiplatform library that allows you to embed
+[Lets-Plot](https://github.com/JetBrains/lets-plot) charts in a Compose Multiplatform application. [Lets-Plot](https://github.com/JetBrains/lets-plot) is a multiplatform plotting library based on [The Grammar of Graphics](https://www.goodreads.com/book/show/2549408.The_Grammar_of_Graphics).  
+![badge][badge-android]
+![badge][badge-ios]
+![badge][badge-js]
+![badge][badge-jvm]
+![badge][badge-linux]
+![badge][badge-windows]
+![badge][badge-mac]
+![badge][badge-wasm]
+
 ### Animation / UI
 
 * [Kottie](https://github.com/ismai117/kottie) - Compose Multiplatform animation library that parses Adobe After Effects animations. Inspired by Lottie  

--- a/README.md
+++ b/README.md
@@ -1480,8 +1480,7 @@
 ![badge][badge-linux]
 ![badge][badge-windows]
 
-* [Lets-Plot Skia Frontend (official)](https://github.com/JetBrains/lets-plot) - a Kotlin Multiplatform library that allows you to embed
-[Lets-Plot](https://github.com/JetBrains/lets-plot) charts in a Compose Multiplatform application. [Lets-Plot](https://github.com/JetBrains/lets-plot) is a multiplatform plotting library based on [The Grammar of Graphics](https://www.goodreads.com/book/show/2549408.The_Grammar_of_Graphics).  
+* [Lets-Plot Skia Frontend (official)](https://github.com/JetBrains/lets-plot) - a Kotlin Multiplatform library that allows you to embed [Lets-Plot](https://github.com/JetBrains/lets-plot) charts in a Compose Multiplatform application. [Lets-Plot](https://github.com/JetBrains/lets-plot) is a multiplatform plotting library based on [The Grammar of Graphics](https://www.goodreads.com/book/show/2549408.The_Grammar_of_Graphics).  
 ![badge][badge-android]
 ![badge][badge-ios]
 ![badge][badge-js]


### PR DESCRIPTION
# Lets-Plot Skia Frontend (Official)

* a (JetBrains official) Kotlin Multiplatform library that allows you to embed [Lets-Plot](https://github.com/JetBrains/lets-plot) charts in a Compose Multiplatform application. [Lets-Plot](https://github.com/JetBrains/lets-plot) is a multiplatform plotting library based on [The Grammar of Graphics](https://www.goodreads.com/book/show/2549408.The_Grammar_of_Graphics).

[Library Link](https://github.com/JetBrains/lets-plot)

---

- [x] Confirmed that two spaces were added at the end of the description to break a new line.  

