### PR TITLE
Fix invalid badge reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@
 ![badge][badge-ios]
 ![badge][badge-watchos]
 ![badge][badge-tvos]
-![badge][badge-macos]
+![badge][badge-mac]
 ![badge][badge-windows]
 ![badge][badge-linux]
 


### PR DESCRIPTION
Closes https://github.com/AAkira/Kotlin-Multiplatform-Libraries/issues/227 

---
This PR fixes the broken badge reference of [kotlinx-murmurhash](https://github.com/goncalossilva/kotlinx-murmurhash) 

```diff
- ![badge][badge-macos] 
+ ![badge][badge-mac]
```
